### PR TITLE
Lint and parametrise

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -10,6 +10,7 @@ Aspects that aren't related to the template being a Python one.
 ### README.md structure
 
 Every repo needs a README file to explain the most basic things about it:
+
 - What is this?
 - What is it built with? (major dependencies)
 - How does one install/use it?
@@ -102,7 +103,7 @@ image with the python package (`make docker-build-release`).
 
 Because of this, we enforce the first commit of new repos, which is templated to
 inform users of the source of the template (down to commit hash of template
-used), to be tagged as `v0.1.0`. 
+used), to be tagged as `v0.1.0`.
 This decision also happens to line up the `CHANGELOG.md` content, which insists
 the current date is release of `v0.1.0`.
 
@@ -132,7 +133,6 @@ in that image is installing poetry itself. Note the release docker image does
 not contain poetry, nor does it need it, only installing the built package via
 `pip`, to minimize dependencies.
 
-
 ### Gitignore
 
 The `.gitignore` file is taken from [Github's gitignore
@@ -155,7 +155,7 @@ instead of disabling reproducibility by default for those who need it.
 ### Use Src folder for holding python package contents
 
 There are many reasons to use an `src/` folder for holding Python package
-source. 
+source.
 
 The simplest one is just to separate where the source code is clearly,
 regardless of the package name. When the package is called for instance
@@ -169,7 +169,7 @@ separate `tests/` folder (rather than encouraging tests inside the package, like
 than allowing relative imports like `from .. import xyz`.
 
 And finally, the most technical reason is the one defined in [Testing &
-packaging](https://hynek.me/articles/testing-packaging/): 
+packaging](https://hynek.me/articles/testing-packaging/):
 > If you use the "ad hoc" layout without an `src/` directory, *your tests do not
 > run against the package as it will be installed by its users*. They run
 > against whatever the situation in your project directory is.
@@ -178,7 +178,6 @@ packaging](https://hynek.me/articles/testing-packaging/):
 
 Since this template is meant for me to build for future work, I have no reason to
 allow older versions of Python to be used in new project.
-
 
 ### Formatters
 
@@ -212,7 +211,6 @@ Mark the package as typed for downstream users via presence of `py.typed` empty
 file.
 
 Use `mypy` to enforce all that typing. It works.
-
 
 ### Pre-commit hooks for linting and formatting
 
@@ -250,8 +248,7 @@ with no HTTP dependency.
 
 Default app has tests for the CLI under use, to prove the CLI can be invoked,
 and that the arguments given make sense. For the HTTP API client, we also test
-separately that the main entrypoint hits the (mocked) requested endpoint. 
-
+separately that the main entrypoint hits the (mocked) requested endpoint.
 
 ### Documentation
 
@@ -270,6 +267,7 @@ project) as first of the docs, to get devs going.
 
 For documentation of the code itself, we lean on the recent `sphinx-autoapi` to
 include the code's API reference.
+
 ### Release Dockerfile force-rebuilds package
 
 The Dockerfile for release is a standalone Dockerfile that force-rebuilds the

--- a/README.md
+++ b/README.md
@@ -17,21 +17,27 @@ Read up on the template's design decisions in the [DESIGN.md](./DESIGN.md) file.
 To install `cookiecutter`, consider using [pipx](https://pypa.github.io/pipx/)
 to isolate the executable from your system:
 
-	pipx install cookiecutter
-	# Inject the dependencies used in this particular template
-	pipx inject cookiecutter jinja2-git
+```shell
+pipx install cookiecutter
+# Inject the dependencies used in this particular template
+pipx inject cookiecutter jinja2-git
+```
 
 Otherwise install it normally via pip, though we encourage you use a virtual
 environment:
 
-	pip install cookiecutter jinja2-git
+```shell
+pip install cookiecutter jinja2-git
+```
 
 ### Using the template
 
-Run cookiecutter with a URL to this repo. This can be done by cloning the repo,
-or directly via repo URL on Github:
+Run cookiecutter with a URL to this repository. This can be done by cloning the
+repository, or directly via repository URL on Github:
 
-	cookiecutter https://github.com/OverkillGuy/python-template
+```shell
+cookiecutter https://github.com/OverkillGuy/python-template
+```
 
 It will then ask questions like python version and project name to get a fresh
 repository, ready for action!
@@ -44,17 +50,21 @@ actually build the project?")
 
 Use the convenient Makefile for testing:
 
-	make      # defaults to target "all"
-	make all  # equivalent
+```shell
+make      # defaults to target "all"
+make all  # equivalent
+```
 
 A target called `make try` with optional parameters `PYTHON_VERSION` and
 `MAKE_TGT` is available to see the template expanded locally, running inside the
-templated repo the make target defined by `MAKE_TGT`:
+templated repository the make target defined by `MAKE_TGT`:
 
-	make try  # defaults to PYTHON_VERSION=3.10 MAKE_TGT=all
-	# You can override these variables:
-	make try PYTHON_VERSION=3.11
-	make try MAKE_TGT=docker-build  # to run make docker-build inside repo
+```shell
+make try  # defaults to PYTHON_VERSION=3.10 MAKE_TGT=all
+# You can override these variables:
+make try PYTHON_VERSION=3.11
+make try MAKE_TGT=docker-build  # to run make docker-build inside repository
+```
 
 ## TODO list
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,6 +5,9 @@
     "project_variant": ["REST_API_client", "just_a_CLI"],
     "project_slug": "{{ cookiecutter.project_name.strip().lower().replace(' ', '-') }}",
     "package_name": "{{ cookiecutter.project_slug.replace('-', '_') }}",
+    "template_url": "https://github.com/OverkillGuy/python-template",
+    "author_name": "Jb Doyon",
+    "author_email": "jb@jiby.tech",
     "_jinja2_env_vars": {"trim_blocks": true},
     "_extensions": ["jinja2_git.GitExtension"]
 }

--- a/hooks/post_gen_project
+++ b/hooks/post_gen_project
@@ -15,8 +15,8 @@ create_git_repository() {
     # Temporarily set commiter name.
     # Nicely solves problem of "missing git user" in CI by making all
     # template instantiation use a set user name/email combo
-    git config --local user.name "Jb Doyon"
-    git config --local user.email "jb@jiby.tech"
+    git config --get user.name > /dev/null || git config --local user.name "Jb Doyon"
+    git config --get user.email > /dev/null || git config --local user.email "jb@jiby.tech"
 
     # Commit
     git add --all
@@ -29,9 +29,9 @@ create_git_repository() {
         --annotate \
         --message "First releasable artefact, from template"
 
-    # Reset the user config after committing
-    git config --unset user.name
-    git config --unset user.email
+    # Reset the user config after committing if fallback values were used
+    git config --unset user.name || true
+    git config --unset user.email || true
 }
 
 # Delete all unused files (marked via specific content string)

--- a/hooks/post_gen_project
+++ b/hooks/post_gen_project
@@ -15,15 +15,15 @@ create_git_repository() {
     # Temporarily set commiter name.
     # Nicely solves problem of "missing git user" in CI by making all
     # template instantiation use a set user name/email combo
-    git config --get user.name > /dev/null || git config --local user.name "Jb Doyon"
-    git config --get user.email > /dev/null || git config --local user.email "jb@jiby.tech"
+    git config --get user.name > /dev/null || git config --local user.name "{{ cookiecutter.author_name }}"
+    git config --get user.email > /dev/null || git config --local user.email "{{ cookiecutter.author_email }}"
 
     # Commit
     git add --all
     git commit \
         --message "Initial commit from cookiecutter template" \
         --message "From python-template repository in Github:" \
-        --message "https://github.com/OverkillGuy/python-template" \
+        --message "{{ cookiecutter.template_url }}" \
         --message "at commit {% gitcommit %}"
     git tag v0.1.0 \
         --annotate \

--- a/hooks/pre_gen_project
+++ b/hooks/pre_gen_project
@@ -2,13 +2,14 @@
 import re
 import sys
 
+MODULE_REGEX = r"^[_a-zA-Z][_a-zA-Z0-9]+$"
 
-MODULE_REGEX = r'^[_a-zA-Z][_a-zA-Z0-9]+$'
-
-module_name = '{{ cookiecutter.package_name}}'
+module_name = "{{ cookiecutter.package_name}}"
 
 if not re.match(MODULE_REGEX, module_name):
-    print(f"ERROR: The project slug ({module_name}) is not a valid Python module name. "
-	 "Please do not use a - and use _ instead")
-    #Exit to cancel project creation
+    print(
+        f"ERROR: The project slug ({module_name}) is not a valid Python "
+        "module name. Please do not use a - and use _ instead"
+    )
+    # Exit to cancel project creation
     sys.exit(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,13 @@ faker-microservice = "2.*"
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
+# Make isort work with Black
+# Avoids conflicting imports
+# As per https://pycqa.github.io/isort/docs/configuration/black_compatibility/#using-a-config-file-such-as-isortcfg
+[tool.isort]
+profile = "black"
+multi_line_output = 3
+
 # Set pytest to record stdout/stderr to junit test result xml
 [tool.pytest.ini_options]
 junit_logging = "all"

--- a/tests/docker.py
+++ b/tests/docker.py
@@ -1,4 +1,4 @@
-"""Useful utilities relating to docker containers """
+"""Useful utilities relating to docker containers"""
 import subprocess
 import sys
 import tarfile
@@ -25,7 +25,8 @@ def print_docker_build_log(build_log_stream):
     # Exhaust the "stream" key while we aren't erroring
     while "error" not in log_item:
         log_acc += log_item["stream"]
-        if "\n" in log_acc:  # TODO: Print separate newline on multiple \n in log_acc
+        # TODO: Print separate newline on multiple \n in log_acc
+        if "\n" in log_acc:
             print(log_acc)
             log_acc = ""
         log_item = next(build_log_stream)
@@ -51,21 +52,24 @@ def python_dev_image(template: Template):
     docker_devimg_name = f"python-skeleton-testing:{py_version}"
     docker_client = docker_or_skip()
     try:
-        img = docker_client.images.build(
+        docker_client.images.build(
             path=str(template.path),
             tag=docker_devimg_name,  # FIXME: Clashing parallel builds
             rm=True,
         )
     except (docker.errors.BuildError) as e:
-        print(f"Failed to build the main templated Dockerfile. Build log:")
+        print("Failed to build the main templated Dockerfile. Build log:")
         print_docker_build_log(e.build_log)
         raise e
     return docker_devimg_name
 
 
-def run_docker_devimg(command, template: Template, raise_on_nonzero_exitcode=True):
+def run_docker_devimg(
+    command,
+    template: Template,
+    raise_on_nonzero_exitcode=True,
+):
     """Run the given command in the dev image
-
 
     Emulate a docker build + docker run + docker cp via docker-py
     """
@@ -86,7 +90,8 @@ def run_docker_devimg(command, template: Template, raise_on_nonzero_exitcode=Tru
             detach=True,
         )
         # Block till container completed
-        response = container.wait(timeout=90)  # TODO: Confirm timeout unit (sec?)
+        # TODO: Confirm timeout unit (sec?)
+        response = container.wait(timeout=90)
         exit_code = response["StatusCode"]
         print(container.logs())
         if exit_code > 0:
@@ -122,7 +127,8 @@ def run_native(command, template: Template):
         # breakpoint()
         if "ython version" in e.stderr.lower():
             pytest.skip(
-                f"Missing python executable for version {template.context['python_version']}"
+                "Missing python executable for version "
+                f"{template.context['python_version']}"
             )
         else:
             print(e.stdout)
@@ -130,7 +136,11 @@ def run_native(command, template: Template):
             raise e
     try:
         subprocess.run(
-            command, cwd=template.path, capture_output=True, text=True, check=True
+            command,
+            cwd=template.path,
+            capture_output=True,
+            text=True,
+            check=True,
         )
         return template.path
     except subprocess.CalledProcessError as e:

--- a/tests/templating.py
+++ b/tests/templating.py
@@ -1,15 +1,12 @@
 """Cookiecutter templating-related utilities"""
-
 import json
 from collections import namedtuple
 
+import faker_microservice
 from cookiecutter import main as ck
+from faker import Faker
 
 Template = namedtuple("Template", ["path", "context", "run_in_dev"])
-
-
-import faker_microservice
-from faker import Faker
 
 fake = Faker()
 fake.add_provider(faker_microservice.Provider)

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -1,12 +1,11 @@
 import os
 import subprocess
-import sys
 from tempfile import TemporaryDirectory
 from typing import Callable, Literal
 
 from cookiecutter.generate import generate_context
 from cookiecutter.prompt import prompt_for_config
-from pytest_cases import fixture, parametrize, parametrize_with_cases
+from pytest_cases import fixture, parametrize
 
 from tests.docker import run_docker_devimg, run_native
 from tests.templating import (

--- a/{{cookiecutter.project_slug}}/.cruft.json
+++ b/{{cookiecutter.project_slug}}/.cruft.json
@@ -1,5 +1,5 @@
 {
-  "template": "https://github.com/OverkillGuy/python-template",
+  "template": "{{ cookiecutter.template_url }}",
   "commit": "{% gitcommit %}",
   "checkout": "main",
   "context": {

--- a/{{cookiecutter.project_slug}}/.cruft.json
+++ b/{{cookiecutter.project_slug}}/.cruft.json
@@ -4,7 +4,7 @@
   "checkout": "main",
   "context": {
     "cookiecutter":
-      {{ cookiecutter | tojson }}
+      {{ cookiecutter | tojson(2) | indent(6) }}
     },
   "directory": null
 }

--- a/{{cookiecutter.project_slug}}/.flake8
+++ b/{{cookiecutter.project_slug}}/.flake8
@@ -1,15 +1,24 @@
 [flake8]
 # Black (formatter) uses 88 characters per line not PEP8's 79
 max-line-length = 88
-# Per-project ignored rules: show rule name + explain why ignored for whole project
+# Disable complaints about the use of assert in tests
+per-file-ignores = tests:S101
 ignore =
-    # "Use of assert detected. The enclosed code will be removed when compiling to optimised byte code."
-    # This is useless in tests/ where we WANT to have asserts
-    S101
-    # "Docstrings first line must end in a period"
-    # Overly strict rule don't serve anyone. PEP8 be damned on this
-    D400
     # "Line too long"
-    # We have "black" formatter to deal with those (splits line), and flake8
-    # still complains about long comments(!!!) automatically
+    # Replaced by B950
     E501
+    # "Line break occurred before a binary operator"
+    # Against PEP8
+    W503
+    # D100-D107: docstrings; disabled until we have docstrings for everything
+    D100
+    D101
+    D102
+    D103
+    D105
+    D107
+    # "Docstrings first line must end in a period"
+    # Overly strict, might be enabled at some point though
+    D400
+# B950: line too long, but tolerates 10% over the limit, like black
+extend-select = B950

--- a/{{cookiecutter.project_slug}}/.markdown-lint.yml
+++ b/{{cookiecutter.project_slug}}/.markdown-lint.yml
@@ -1,0 +1,5 @@
+---
+MD024:
+  # Allow duplicate heading names under different parent headings (doesn't
+  # complain about multiple "Added" headings in changelog, for example)
+  allow_different_nesting: true

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -1,57 +1,64 @@
+---
 exclude: "^docs/source/conf.py$"
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
-    hooks:
-    -   id: trailing-whitespace
-    -   id: end-of-file-fixer
-    -   id: check-added-large-files
-    -   id: check-executables-have-shebangs
-    -   id: check-case-conflict
-    -   id: check-vcs-permalinks
-    -   id: forbid-new-submodules
-    -   id: mixed-line-ending
-    -   id: check-merge-conflict
-    -   id: detect-private-key
-    -   id: detect-aws-credentials
-        args: [ '--allow-missing-credentials']  # Avoid failure on CI
-    -   id: check-toml
-    -   id: check-yaml
-    -   id: check-json
--   repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.8.0.4
-    hooks:
-    -   id: shellcheck
-        name: Shellcheck
-        args: ["-f", "gcc"]  # output filename:linenum:colnum (clickable)
--   repo: https://github.com/AleksaC/hadolint-py
-    rev: v2.10.0
-    hooks:
-      - id: hadolint
-        name: Hadolint (Dockerfile checker)
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.3.0
+  hooks:
+  - id: trailing-whitespace
+  - id: end-of-file-fixer
+  - id: check-added-large-files
+  - id: check-executables-have-shebangs
+  - id: check-case-conflict
+  - id: check-vcs-permalinks
+  - id: forbid-new-submodules
+  - id: mixed-line-ending
+  - id: check-merge-conflict
+  - id: detect-private-key
+  - id: detect-aws-credentials
+    args: ['--allow-missing-credentials']  # Avoid failure on CI
+  - id: check-toml
+  - id: check-yaml
+  - id: check-json
+- repo: https://github.com/shellcheck-py/shellcheck-py
+  rev: v0.8.0.4
+  hooks:
+  - id: shellcheck
+    name: Shellcheck
+    args: ["-f", "gcc"]  # output filename:linenum:colnum (clickable)
+- repo: https://github.com/AleksaC/hadolint-py
+  rev: v2.10.0
+  hooks:
+  - id: hadolint
+    name: Hadolint (Dockerfile checker)
 # Actual Python Linters
--   repo: https://github.com/psf/black
-    rev: 22.10.0
-    hooks:
-      - id: black
-        name: Black (Python formatter)
--   repo: https://github.com/pycqa/isort
-    rev: 5.10.1
-    hooks:
-      - id: isort
-        name: isort (Python import sorter)
--   repo: https://github.com/pycqa/flake8
-    rev: 5.0.4
-    hooks:
-    -   id: flake8
-        name: Flake8 (Python linter)
-        args: ["--output-file", "test_results/flake8.txt", "--tee", "src/", "tests/"]
-        additional_dependencies:
-          - "flake8-bandit==4.1.1"
-          - "flake8-bugbear==22.8.23"
-          - "flake8-docstrings==1.6.0"
--   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.982
-    hooks:
-    -   id: mypy
-        name: Mypy (Python type-checker)
+- repo: https://github.com/psf/black
+  rev: 22.10.0
+  hooks:
+  - id: black
+    name: Black (Python formatter)
+- repo: https://github.com/pycqa/isort
+  rev: 5.10.1
+  hooks:
+  - id: isort
+    name: isort (Python import sorter)
+- repo: https://github.com/pycqa/flake8
+  rev: 5.0.4
+  hooks:
+  - id: flake8
+    name: Flake8 (Python linter)
+    args: [
+      "--output-file",
+      "test_results/flake8.txt",
+      "--tee",
+      "src/",
+      "tests/"
+    ]
+    additional_dependencies:
+    - "flake8-bandit==4.1.1"
+    - "flake8-bugbear==22.8.23"
+    - "flake8-docstrings==1.6.0"
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v0.982
+  hooks:
+  - id: mypy
+    name: Mypy (Python type-checker)

--- a/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
+++ b/{{cookiecutter.project_slug}}/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 exclude: "^docs/source/conf.py$"
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.3.0
+  rev: v4.4.0
   hooks:
   - id: trailing-whitespace
   - id: end-of-file-fixer
@@ -32,21 +32,24 @@ repos:
     name: Hadolint (Dockerfile checker)
 # Actual Python Linters
 - repo: https://github.com/psf/black
-  rev: 22.10.0
+  rev: 22.12.0
   hooks:
   - id: black
     name: Black (Python formatter)
 - repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+  rev: 5.12.0
   hooks:
   - id: isort
     name: isort (Python import sorter)
 - repo: https://github.com/pycqa/flake8
-  rev: 5.0.4
+  rev: 6.0.0
   hooks:
   - id: flake8
     name: Flake8 (Python linter)
+    # flake8 refuses to use pyproject.toml, needs a separate config.
+    # See https://github.com/PyCQA/flake8/issues/234
     args: [
+      "--config=.flake8",
       "--output-file",
       "test_results/flake8.txt",
       "--tee",
@@ -54,11 +57,31 @@ repos:
       "tests/"
     ]
     additional_dependencies:
-    - "flake8-bandit==4.1.1"
+    # Bandit is currently disabled it because doesn't seem to respect
+    # per-file-ignores=tests:S101 and keeps complaining about asserts
+    # in tests.
+    # - "flake8-bandit==4.1.1"
     - "flake8-bugbear==22.8.23"
     - "flake8-docstrings==1.6.0"
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.982
+  rev: v0.991
   hooks:
   - id: mypy
     name: Mypy (Python type-checker)
+    # Uncomment below if mypy requires extra type stub packages
+    # additional_dependencies: [types-PyYAML==6.0.12.2]
+- repo: https://github.com/igorshubovych/markdownlint-cli
+  rev: v0.32.2
+  hooks:
+  - id: markdownlint
+    args: ["--config", ".markdown-lint.yml"]
+- repo: https://github.com/adrienverge/yamllint.git
+  rev: v1.17.0
+  hooks:
+  - id: yamllint
+    args: [
+      "-d",
+      # Allows both indented and unindented list, as long as the whole document
+      # uses consistent indentation
+      "{extends: default, rules: {indentation: {indent-sequences: consistent}}}"
+    ]

--- a/{{cookiecutter.project_slug}}/CHANGELOG.md
+++ b/{{cookiecutter.project_slug}}/CHANGELOG.md
@@ -1,13 +1,12 @@
 # Changelog for {{ cookiecutter.project_name }}
 
-
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
-The project uses semantic versioning (see [semver](https://semver.org)).
+The project uses semantic versioning (see [SemVer](https://semver.org)).
 
 ## [Unreleased]
 
-
-## v0.1.0 - {% now 'local' %}
+## v0.1.0 - {% now 'local' +%}
 
 ### Added
+
 - New python module `{{ cookiecutter.package_name }}`, exposed as shell command `{{ cookiecutter.project_slug }}`

--- a/{{cookiecutter.project_slug}}/Makefile
+++ b/{{cookiecutter.project_slug}}/Makefile
@@ -54,9 +54,9 @@ release:
 # Set the new version Makefile variable after the version bump
 	$(eval NEW_VERSION := $(shell poetry version --short ${BUMP}))
 	sed -i \
-		"s/\(## \[Unreleased\]\)/\1\n\n\n## v${NEW_VERSION} - $(shell date -I)/" \
+		"s/\(## \[Unreleased\]\)/\1\n\n## v${NEW_VERSION} - $(shell date -I)/" \
 		CHANGELOG.md
-	git add -A
+	git add CHANGELOG.md pyproject.toml
 	git commit -m "Bump to version v${NEW_VERSION}"
 	git tag -a v${NEW_VERSION} \
 		-m "Release v${NEW_VERSION}"

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -4,7 +4,6 @@
 
 Requires Python {{cookiecutter.python_version}}
 
-
 ## Usage
 
 Depends on what the code in there does.
@@ -13,20 +12,24 @@ Depends on what the code in there does.
 
 Install the module first:
 
-    make install
-    # or
-    poetry install
+```shell
+make install
+# or
+poetry install
+```
 
 Then inside the virtual environment, launch the command:
 
-    # Run single command inside virtualenv
-    poetry run {{ cookiecutter.project_slug }}
+```shell
+# Run single command inside virtualenv
+poetry run {{ cookiecutter.project_slug }}
 
-    # or
-    # Load the virtualenv first
-    poetry shell
-    # Then launch the command, staying in virtualenv
-    {{ cookiecutter.project_slug }}
+# or
+# Load the virtualenv first
+poetry shell
+# Then launch the command, staying in virtualenv
+{{ cookiecutter.project_slug }}
+```
 
 ## Development
 
@@ -39,24 +42,26 @@ Python package inside `src/{{cookiecutter.package_name}}/`.
 `poetry` will create virtual environments if needed, fetch
 dependencies, and install them for development.
 
-
 For ease of development, a `Makefile` is provided, use it like this:
 
-	make  # equivalent to "make all" = install lint docs test build
-	# run only specific tasks:
-	make install
-	make lint
-	make test
-	# Combine tasks:
-	make install test
+```shell
+make  # equivalent to "make all" = install lint docs test build
+# run only specific tasks:
+make install
+make lint
+make test
+# Combine tasks:
+make install test
+```
 
 Once installed, the module's code can now be reached through running
 Python in Poetry:
 
-	$ poetry run python
-	>>> from {{cookiecutter.package_name}} import main
-	>>> main("blabla")
-
+```shell
+$ poetry run python
+>>> from {{cookiecutter.package_name}} import main
+>>> main("blabla")
+```
 
 This codebase uses [pre-commit](https://pre-commit.com) to run linting
 tools like `flake8`. Use `pre-commit install` to install git
@@ -76,21 +81,27 @@ generate API reference without headaches.
 
 To build the documentation, run
 
-    # Requires the project dependencies provided by "make install"
-    make docs
-	# Generates docs/build/html/
+```shell
+# Requires the project dependencies provided by "make install"
+make docs
+# Generates docs/build/html/
+```
 
-To browse the website version of the documentation you just built, run:
+To browse the web version of the documentation you just built, run:
 
-    make docs-serve
+```shell
+make docs-serve
+```
 
 And remember that `make` supports multiple targets, so you can generate the
 documentation and serve it:
 
-    make docs docs-serve
-
+```shell
+make docs docs-serve
+```
 
 ### Templated repository
 
-This repo was created by the cookiecutter template available at
-https://github.com/OverkillGuy/python-template, using commit hash: `{% gitcommit %}`.
+This repository was created by the cookiecutter template available at
+<https://github.com/OverkillGuy/python-template>,
+using commit hash: `{% gitcommit %}`.

--- a/{{cookiecutter.project_slug}}/README.md
+++ b/{{cookiecutter.project_slug}}/README.md
@@ -103,5 +103,5 @@ make docs docs-serve
 ### Templated repository
 
 This repository was created by the cookiecutter template available at
-<https://github.com/OverkillGuy/python-template>,
+<{{ cookiecutter.template_url }}>,
 using commit hash: `{% gitcommit %}`.

--- a/{{cookiecutter.project_slug}}/docs/source/changelog.md
+++ b/{{cookiecutter.project_slug}}/docs/source/changelog.md
@@ -1,3 +1,5 @@
+# Changelog
+
 Below is the rendered version of the project's `CHANGELOG.md` file, found at the
 root of the code repository.
 

--- a/{{cookiecutter.project_slug}}/docs/source/conf.py
+++ b/{{cookiecutter.project_slug}}/docs/source/conf.py
@@ -19,8 +19,8 @@ sys.path.insert(0, os.path.abspath("../../src"))
 # -- Project information -----------------------------------------------------
 
 project = "{{ cookiecutter.project_name }}"
-copyright = "2022, Jb Doyon"
-author = "Jb Doyon"
+copyright = "2022, {{ cookiecutter.author_name }}"
+author = "{{ cookiecutter.author_name }}"
 
 
 # -- General configuration ---------------------------------------------------

--- a/{{cookiecutter.project_slug}}/docs/source/conf.py
+++ b/{{cookiecutter.project_slug}}/docs/source/conf.py
@@ -19,7 +19,7 @@ sys.path.insert(0, os.path.abspath("../../src"))
 # -- Project information -----------------------------------------------------
 
 project = "{{ cookiecutter.project_name }}"
-copyright = "2022, {{ cookiecutter.author_name }}"
+copyright = "2023, {{ cookiecutter.author_name }}"
 author = "{{ cookiecutter.author_name }}"
 
 

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -2,7 +2,7 @@
 name = "{{cookiecutter.package_name}}"
 version = "0.1.0"
 description = "{{cookiecutter.description}}"
-authors = ["Jb Doyon <jb@jiby.tech>"]
+authors = ["{{ cookiecutter.author_name }} <{{ cookiecutter.author_email }}>"]
 readme = "README.md"
 
 [tool.poetry.scripts]

--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -67,3 +67,4 @@ addopts = """-vv \
 
 [tool.mypy]
 python_version = "{{ cookiecutter.python_version }}"
+check_untyped_defs = true

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.package_name}}/api.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.package_name}}/api.py
@@ -33,7 +33,7 @@ def get_from_api(token: Secret) -> dict:
     api_response = api_get(headers)
     return api_response
 {% else %}
-{# Cookiecutter doesn't include files conditionally, but CAN set sentinel string and use
- # post-gen hooks to delete the file themselves #}
+{# Cookiecutter doesn't include files conditionally, but CAN set sentinel
+ # string and use post-gen hooks to delete the file themselves #}
 DELETE THIS FILE DURING POST_GEN HOOK
 {% endif %}

--- a/{{cookiecutter.project_slug}}/src/{{cookiecutter.package_name}}/cli.py
+++ b/{{cookiecutter.project_slug}}/src/{{cookiecutter.package_name}}/cli.py
@@ -23,7 +23,9 @@ def parse_arguments(arguments: list[str]) -> argparse.Namespace:
     )
 {% if cookiecutter.project_variant == "REST_API_client" %}
     parser.add_argument(
-        "--token-file", help="File containing API Token", type=argparse.FileType("r")
+        "--token-file",
+        help="File containing API Token",
+        type=argparse.FileType("r"),
     )
 {% else %}
     parser.add_argument("foo", help="Some parameter")
@@ -43,7 +45,8 @@ def cli(arguments: Optional[list[str]] = None):
         token = os.getenv("API_TOKEN")
     if token is None:
         print(
-            "Missing API token: --token-file or set API_TOKEN envvar", file=sys.stderr
+            "Missing API token: --token-file or set API_TOKEN envvar",
+            file=sys.stderr,
         )
         exit(2)  # Simulate the argparse behaviour of exiting on bad args
     main(token)


### PR DESCRIPTION
Some linting, QoL changes and parametrising author details.

- Ran the python code through the black formatter
- Ran yaml, markdown through a linter
- Tweaked flake8 to be slightly more lenient with line length
- The initial commit now automatically uses configured git author, if set
- Author name and email, template URL can now be passed as parameters
  - The template URL doesn't affect cookiecutter itself, just the references in the initial commit, README etc
- ~~Added pre-commit inside the virtual environment (dev group)~~
  - ~~That way the user doesn't need to install the package separately~~

I've also changed the max line length back to 79 in my own fork, but decided not to include the commit here, because that's just my own opinion and not an objective change.