### PR TITLE
Generate annotated tags instead of lightweight tags on `make release`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ templating versions are not perfect matches for semantic versions.
 
 ## [Unreleased]
 
+### Changed
+
+- Now generates annotated git tags instead of lightweight tags on `make
+  release`.
+
 ## v1.4.0 - 2023-10-06
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -69,4 +69,4 @@ release:
 		CHANGELOG.md
 	git add CHANGELOG.md pyproject.toml
 	git commit -m "Bump version for template v${NEW_VERSION}"
-	git tag "v${NEW_VERSION}"
+	git tag -am "Release v${NEW_VERSION}" "v${NEW_VERSION}"


### PR DESCRIPTION
From `man git-tag`:

> Annotated tags are meant for release while lightweight tags are meant for private or temporary object labels. For this reason, some git commands for naming objects (like git describe) will ignore lightweight tags by default.

Currently the annotation is just the tag name, this could also be changed to something more verbose.