### PR TITLE
Ignore requirements.txt in the expanded template

### DIFF
--- a/template/.gitignore.j2
+++ b/template/.gitignore.j2
@@ -6,4 +6,8 @@ poetry.lock
 # do matter a lot, and you'll want to keep Poetry.lock tracked = keep
 # commented
 
+# requirements.txt is exported during the docker build, it does not need to be
+# committed in the repo
+requirements.txt
+
 {% include "data/ignores.j2" -%}


### PR DESCRIPTION
pyproject.toml already defines the dependencies, no need to commit requirements.txt after it's generated by `make docker-build-release`.