### PR TITLE
Makefile: Allow setting a container registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ templating versions are not perfect matches for semantic versions.
 - New `make check-requirements`, verifies `requirements.txt` == `poetry.lock`.
 - Release-oriented dockerfile uses built CLI as entrypoint.
   Can now run `docker run {{ project-slug }}:0.1.0 --help`.
+- Allow setting a container registry when building. Run `make
+  DOCKER_REGISTRY=docker.io/example/ docker-build-release` to automatically tag
+  the image with a specific registry.
 
 ## v1.3.1 - 2023-09-05
 

--- a/template/Makefile.j2
+++ b/template/Makefile.j2
@@ -1,4 +1,5 @@
 DOCKER_IMAGE_NAME={{project_slug}}
+DOCKER_REGISTRY=
 APP_VERSION=$(shell poetry version --short)
 
 .PHONY: all
@@ -41,7 +42,7 @@ build:
 .PHONY: docker-build-release
 docker-build-release: export-requirements
 	docker build \
-		-t "${DOCKER_IMAGE_NAME}:${APP_VERSION}" \
+		-t "${DOCKER_REGISTRY}${DOCKER_IMAGE_NAME}:${APP_VERSION}" \
 		-f release.Dockerfile \
 		.
 


### PR DESCRIPTION
Allows running `make DOCKER_REGISTRY=docker.io/example/ docker-build-release` to automatically tag the image with a specific registry.