### PR TITLE
Reduce docker cache invalidation

### DIFF
--- a/template/.dockerignore
+++ b/template/.dockerignore
@@ -8,6 +8,12 @@
 
 test_results/
 
+# Prevent accidental cache invalidation by ignoring text editor temp and backup
+# files as well as the git tree
+*~
+*.swp
+.git
+
 ## Python gitignore from github/gitignored#14f8a8b
 ## See https://raw.githubusercontent.com/github/gitignore/14f8a8b4c51ecc00b18905a95c117954e6c77b9d/Python.gitignore
 


### PR DESCRIPTION
This prevents invalidating the build cache accidentally when temporary files or backup files change in the worktree, or when git operations such as branch creation are performed.

~~gitignore is just for general cleanliness~~